### PR TITLE
Structural changes to the deserializer

### DIFF
--- a/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
@@ -13,9 +13,9 @@ object ThriftDeserializer {
     * the first byte for details on how the value is encoded. Plain
     * values can be decoded by setting the `noHeader` flag to `true`.
     */
-  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte], noHeader: Boolean = false): Try[T] =
+  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte], noHeader: Boolean): Try[T] =
     Try {
-      if (!noSettings) {
+      if (!noHeader) {
         val settings = buffer.head
         val compressionType = compression(settings)
         compressionType match {
@@ -25,6 +25,13 @@ object ThriftDeserializer {
         }
       } else payload(buffer)
     }
+
+  /** Reads a Thrift value from a byte array. Tries to read the first byte
+    * for details on how the value is encoded and decode accordingly, or
+    * decode as a plain value if it fails.
+    */
+  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte]): Try[T] =
+    deserialize(buffer, false) orElse deserialize(buffer, true)
 
   private def compression(settings: Byte): CompressionType = {
     val compressionMask = 0x07.toByte

--- a/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
@@ -7,11 +7,9 @@ import org.apache.thrift.protocol.TCompactProtocol
 import org.apache.thrift.transport.TIOStreamTransport
 import scala.util.Try
 
-trait ThriftDeserializer[T <: ThriftStruct] {
+object ThriftDeserializer {
 
-  val codec: ThriftStructCodec[T]
-
-  def deserialize(buffer: Array[Byte], noSettings: Boolean = false): Try[T] =
+  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte], noSettings: Boolean = false): Try[T] =
     Try {
       if (!noSettings) {
         val settings = buffer.head
@@ -35,7 +33,7 @@ trait ThriftDeserializer[T <: ThriftStruct] {
     }
   }
 
-  private def payload(buffer: Array[Byte]): T = {
+  private def payload[T <: ThriftStruct](buffer: Array[Byte])(implicit codec: ThriftStructCodec[T]): T = {
     val byteBuffer: ByteBuffer = ByteBuffer.wrap(buffer)
     val bbis = new ByteBufferBackedInputStream(byteBuffer)
     val transport = new TIOStreamTransport(bbis)

--- a/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
@@ -9,7 +9,11 @@ import scala.util.Try
 
 object ThriftDeserializer {
 
-  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte], noSettings: Boolean = false): Try[T] =
+  /** Reads a Thrift value from a byte array. By default, will try to read
+    * the first byte for details on how the value is encoded. Plain
+    * values can be decoded by setting the `noHeader` flag to `true`.
+    */
+  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte], noHeader: Boolean = false): Try[T] =
     Try {
       if (!noSettings) {
         val settings = buffer.head

--- a/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
@@ -5,17 +5,14 @@ import java.nio.ByteBuffer
 import com.twitter.scrooge.{ThriftStruct, ThriftStructCodec}
 import org.apache.thrift.protocol.TCompactProtocol
 import org.apache.thrift.transport.TIOStreamTransport
-
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
 
 trait ThriftDeserializer[T <: ThriftStruct] {
 
   val codec: ThriftStructCodec[T]
 
-  def deserialize(buffer: Array[Byte], noSettings: Boolean = false): Future[T] = {
-    Future {
-
+  def deserialize(buffer: Array[Byte], noSettings: Boolean = false): Try[T] =
+    Try {
       if (!noSettings) {
         val settings = buffer.head
         val compressionType = compression(settings)
@@ -25,9 +22,7 @@ trait ThriftDeserializer[T <: ThriftStruct] {
           case ZstdType => payload(ZstdCompression.uncompress(buffer.tail))
         }
       } else payload(buffer)
-
     }
-  }
 
   private def compression(settings: Byte): CompressionType = {
     val compressionMask = 0x07.toByte

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -2,7 +2,7 @@ package com.gu.thrift.serializer
 
 import com.gu.auditing.model.v1.{App, Notification}
 import org.scalatest.{FreeSpec, Matchers}
-import org.scalatest.concurrent.ScalaFutures
+import scala.util.Success
 
 class ThriftSerializerTest extends FreeSpec with Matchers {
 
@@ -21,10 +21,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     }
 
     "serialized and deserialized back to itself" in {
-
-      ScalaFutures.whenReady(NotificationDeserializer.deserialize(bytes)) { result =>
-        result should be(notification)
-      }
+      NotificationDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 
@@ -38,9 +35,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
     "serialized and deserialized back to itself" in {
 
-      ScalaFutures.whenReady(NotificationDeserializer.deserialize(bytes)) { result =>
-        result should be(notification)
-      }
+      NotificationDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 
@@ -54,9 +49,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     }
 
     "serialized and deserialized back to itself" in {
-      ScalaFutures.whenReady(NotificationDeserializer.deserialize(bytes)) { result =>
-        result should be(notification)
-      }
+      NotificationDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 
@@ -67,9 +60,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true)
 
     "serialized and deserialized back to itself" in {
-      ScalaFutures.whenReady(NotificationDeserializer.deserialize(bytes, true)) { result =>
-        result should be(notification)
-      }
+      NotificationDeserializer.deserialize(bytes, true) should be(Success(notification))
     }
   }
 
@@ -77,22 +68,16 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
     val errorMessage = "The compression type: 3 is not supported"
     val bytes = Array.fill[Byte](2)(0x03.toByte)
-    val future = NotificationDeserializer.deserialize(bytes)
 
-    ScalaFutures.whenReady(NotificationDeserializer.deserialize(bytes).failed) { error =>
-      error.getMessage should be (errorMessage)
-    }
+    NotificationDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
 
   }
   "deserilization throws when invalid set of bytes" in {
 
     val errorMessage = "Required field 'app' was not found in serialized data for struct Notification"
     val bytes = Array.fill[Byte](5)(0x00.toByte)
-    val future = NotificationDeserializer.deserialize(bytes)
 
-    ScalaFutures.whenReady(NotificationDeserializer.deserialize(bytes).failed) { error =>
-      error.getMessage() should be (errorMessage)
-    }
+    NotificationDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
 
   }
 }

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -6,9 +6,7 @@ import scala.util.Success
 
 class ThriftSerializerTest extends FreeSpec with Matchers {
 
-  object NotificationDeserializer extends ThriftDeserializer[Notification] {
-    val codec = Notification
-  }
+  implicit val codec = Notification
 
   val notification = Notification(App.FaciaTool, "operation", "email", "date", Some("id"), Some("message"))
 
@@ -21,7 +19,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     }
 
     "serialized and deserialized back to itself" in {
-      NotificationDeserializer.deserialize(bytes) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 
@@ -35,7 +33,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
     "serialized and deserialized back to itself" in {
 
-      NotificationDeserializer.deserialize(bytes) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 
@@ -49,7 +47,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     }
 
     "serialized and deserialized back to itself" in {
-      NotificationDeserializer.deserialize(bytes) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 
@@ -60,7 +58,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true)
 
     "serialized and deserialized back to itself" in {
-      NotificationDeserializer.deserialize(bytes, true) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes, true) should be(Success(notification))
     }
   }
 
@@ -69,7 +67,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val errorMessage = "The compression type: 3 is not supported"
     val bytes = Array.fill[Byte](2)(0x03.toByte)
 
-    NotificationDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
+    ThriftDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
 
   }
   "deserilization throws when invalid set of bytes" in {
@@ -77,7 +75,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val errorMessage = "Required field 'app' was not found in serialized data for struct Notification"
     val bytes = Array.fill[Byte](5)(0x00.toByte)
 
-    NotificationDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
+    ThriftDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
 
   }
 }

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -67,7 +67,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val errorMessage = "The compression type: 3 is not supported"
     val bytes = Array.fill[Byte](2)(0x03.toByte)
 
-    ThriftDeserializer.deserialize(bytes).failed.map(_.getMessage) should be (Success(errorMessage))
+    ThriftDeserializer.deserialize(bytes, false).failed.map(_.getMessage) should be (Success(errorMessage))
 
   }
   "deserilization throws when invalid set of bytes" in {

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -58,7 +58,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true)
 
     "serialized and deserialized back to itself" in {
-      ThriftDeserializer.deserialize(bytes, true) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 


### PR DESCRIPTION
After some [feedback](https://github.com/guardian/ophan/pull/3046) from @rtyley , I did the following:

- https://github.com/guardian/thrift-serializer/commit/cb814d7875452d932922890b61e83fae25a5f1b2 Remove `Future`: the only effect we want to capture is the potential for failure, users can then decide to lift it into asynchronous computations if they really need it
- https://github.com/guardian/thrift-serializer/commit/dda407c558c2a96880dff17ae821fd135a80d8f2 replace the cake pattern with constraints on the functions themselves, since the logic applies similarly to all types satisfying `_ <: ThriftStruct`
- https://github.com/guardian/thrift-serializer/commit/78cb3a376356f51c670a045d10d10f0f73211579 renames the `noSettings` parameter and adds some docs, also a second version of `deserialize` will try both alternatives (I had to make `noHeader` mandatory)