### PR TITLE
Bump scrooge version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ import ReleaseStateTransformations._
 
 name := "thrift-serializer"
 organization := "com.gu"
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-    "com.twitter" %% "scrooge-core" % "4.15.0",
+    "com.twitter" %% "scrooge-core" % "19.3.0",
     "org.apache.thrift" % "libthrift" % "0.10.0",
     "com.github.luben" % "zstd-jni" % "1.3.5-2",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test"
@@ -38,7 +38,7 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-crossScalaVersions := Seq("2.11.12", "2.12.7")
+crossScalaVersions := Seq("2.11.12", "2.12.8")
 
 releaseCrossBuild := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // Additional information on initialization
 logLevel := Level.Warn
 
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.15.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 


### PR DESCRIPTION
I'm surprised the library is already using libthrift v0.10, which is great! Perhaps this is a good thing for when we update Porter to the same version. Anyways, we're now upgrading our scrooge/libthrift dependencies across the board.