### PR TITLE
bump libthrift for snyk, plus sbt update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,15 @@ scalaVersion := "2.13.1"
 libraryDependencies ++= Seq(
     "com.twitter" %% "scrooge-core" % "19.9.0",
     "org.apache.thrift" % "libthrift" % "0.12.0",
+  // this has optimised native binaries for all platforms, so is only worth for long lived apps
     "com.github.luben" % "zstd-jni" % "1.3.5-2",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 // Settings for building the thrift definition used in test
-scroogeThriftSourceFolder in Test <<= baseDirectory {
+scroogeThriftSourceFolder in Test := { baseDirectory {
     base => base / "src/test/thrift"
-}
+}.value }
 scroogeThriftOutputFolder in Test := (sourceManaged in Test).value
 managedSourceDirectories in Test += (scroogeThriftOutputFolder in Test).value
 
@@ -38,7 +39,7 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1")
 
 releaseCrossBuild := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.3.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,9 +3,9 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.9.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 


### PR DESCRIPTION
due to this vuln https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-474610
we need to update support-frontend.
This library is pulled in via this project (and acquisition-event-producer) so I should ideally update the whole chain rather than doing a runtime substitutuion.