### PR TITLE
Version updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ name := "thrift-serializer"
 organization := "com.gu"
 scalaVersion := "2.13.9"
 
+ThisBuild / versionScheme := Some("semver-spec")
+
 libraryDependencies ++= Seq(
     "com.twitter" %% "scrooge-core" % "22.1.0",
     "org.apache.thrift" % "libthrift" % "0.17.0",
@@ -14,11 +16,11 @@ libraryDependencies ++= Seq(
 )
 
 // Settings for building the thrift definition used in test
-scroogeThriftSourceFolder in Test := { baseDirectory {
+Test / scroogeThriftSourceFolder := { baseDirectory {
     base => base / "src/test/thrift"
 }.value }
-scroogeThriftOutputFolder in Test := (sourceManaged in Test).value
-managedSourceDirectories in Test += (scroogeThriftOutputFolder in Test).value
+Test / scroogeThriftOutputFolder := (Test / sourceManaged).value
+Test / managedSourceDirectories += (Test / scroogeThriftOutputFolder).value
 
 // Publish settings
 scmInfo := Some(ScmInfo(url("https://github.com/guardian/thrift-serializer"),
@@ -39,7 +41,13 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-crossScalaVersions := Seq("2.12.11", "2.13.1")
+crossScalaVersions := Seq("2.12.17", "2.13.9")
+publishTo := Some(
+    if (isSnapshot.value)
+        Opts.resolver.sonatypeSnapshots
+    else
+        Opts.resolver.sonatypeStaging
+)
 
 releaseCrossBuild := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseStateTransformations._
 
 name := "thrift-serializer"
 organization := "com.gu"
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.8"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 ThisBuild / versionScheme := Some("semver-spec")

--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,11 @@ import ReleaseStateTransformations._
 
 name := "thrift-serializer"
 organization := "com.gu"
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.9"
 
 libraryDependencies ++= Seq(
-    "com.twitter" %% "scrooge-core" % "19.9.0",
-    "org.apache.thrift" % "libthrift" % "0.12.0",
+    "com.twitter" %% "scrooge-core" % "22.1.0",
+    "org.apache.thrift" % "libthrift" % "0.17.0",
   // this has optimised native binaries for all platforms, so is only worth for long lived apps
     "com.github.luben" % "zstd-jni" % "1.3.5-2",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test"
@@ -39,7 +39,7 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1")
+crossScalaVersions := Seq("2.12.11", "2.13.1")
 
 releaseCrossBuild := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ name := "thrift-serializer"
 organization := "com.gu"
 scalaVersion := "2.13.9"
 
+credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 ThisBuild / versionScheme := Some("semver-spec")
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // Additional information on initialization
 logLevel := Level.Warn
 
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.9.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "22.1.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 

--- a/src/main/scala/com/gu/thrift/serializer/Compression.scala
+++ b/src/main/scala/com/gu/thrift/serializer/Compression.scala
@@ -3,8 +3,8 @@ package com.gu.thrift.serializer
 import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
 
 import java.io._
+import java.nio.ByteBuffer
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
-
 import scala.annotation.tailrec
 
 sealed trait CompressionType
@@ -24,15 +24,15 @@ object GzipCompression {
       case e: IOException => throw new RuntimeException(e)
     }
 
-  def uncompress(data: Array[Byte]): Array[Byte] =
+  def uncompress(data: ByteBuffer): ByteBuffer =
     try {
       val bos = new ByteArrayOutputStream()
-      val bis = new ByteArrayInputStream(data)
+      val bis = new ByteBufferBackedInputStream(data)
       val in = new GZIPInputStream(bis)
       IOUtils.copy(in, bos)
       in.close()
       bos.close()
-      bos.toByteArray()
+      ByteBuffer.wrap(bos.toByteArray)
     } catch {
       case e: IOException => throw new RuntimeException(e)
     }
@@ -50,14 +50,14 @@ object ZstdCompression {
       case e: IOException => throw new RuntimeException(e)
     }
   
-  def uncompress(data: Array[Byte]): Array[Byte] = 
+  def uncompress(data: ByteBuffer): ByteBuffer =
     try {
       val bos = new ByteArrayOutputStream()
-      val in = new ZstdInputStream(new ByteArrayInputStream(data))
+      val in = new ZstdInputStream(new ByteBufferBackedInputStream(data))
       IOUtils.copy(in, bos)
       in.close()
       bos.close()
-      bos.toByteArray
+      ByteBuffer.wrap(bos.toByteArray)
     } catch {
       case e: IOException => throw new RuntimeException(e)
     }

--- a/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
@@ -32,8 +32,8 @@ object ThriftDeserializer {
     */
   def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte], noHeader: Boolean): Try[T] = deserialize(ByteBuffer.wrap(buffer), noHeader)
 
-  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte]):Try[T] = deserialize(buffer, false)
-  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: ByteBuffer):Try[T] = deserialize(buffer, false)
+  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: Array[Byte]):Try[T] = deserialize(buffer, false) orElse deserialize(buffer, true)
+  def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: ByteBuffer):Try[T] = deserialize(buffer, false) orElse deserialize(buffer, true)
 
   private def compression(settings: Byte): CompressionType = {
     val compressionMask = 0x07.toByte

--- a/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftDeserializer.scala
@@ -14,7 +14,7 @@ object ThriftDeserializer {
     */
   def deserialize[T <: ThriftStruct : ThriftStructCodec](buffer: ByteBuffer, noHeader: Boolean): Try[T] = Try {
     if(!noHeader) {
-      val settings = buffer.get(0)
+      val settings = buffer.get() //also increments buffer position by 1, so buffer.slice() below returns the "tail"
       val compressionType = compression(settings)
       compressionType match {
         case NoneType => payload(buffer.slice())

--- a/src/main/scala/com/gu/thrift/serializer/ThriftSerializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftSerializer.scala
@@ -1,10 +1,13 @@
 package com.gu.thrift.serializer
 
-import java.lang.{Byte => JByte}
+import com.twitter.io.Buf.ByteArray
 
+import java.lang.{Byte => JByte}
 import com.twitter.scrooge.ThriftStruct
 import org.apache.thrift.protocol.TCompactProtocol
 import org.apache.thrift.transport.TMemoryBuffer
+
+import java.nio.ByteBuffer
 
 object ThriftSerializer {
 
@@ -12,7 +15,7 @@ object ThriftSerializer {
   private val initialBufferDefault = 128
 
   def serializeToBytes(struct: ThriftStruct, userCompressionType: Option[CompressionType],
-    thriftBufferInitialSize: Option[Int], withSettings: Boolean=false): Array[Byte] = {
+    thriftBufferInitialSize: Option[Int], withSettings: Boolean=false): ByteBuffer = {
 
     val bufferSize = thriftBufferInitialSize.getOrElse(initialBufferDefault)
     val buffer = new TMemoryBuffer(bufferSize)
@@ -39,8 +42,8 @@ object ThriftSerializer {
       */
      val settings: Byte = (other & compression).toByte
 
-     settings +: payload(buffer.getArray, compressionType)
-    } else buffer.getArray
+     ByteBuffer.wrap(settings +: payload(buffer.getArray, compressionType))
+    } else ByteBuffer.wrap(buffer.getArray)
   }
 
   private def payload(data: Array[Byte], compressionType: CompressionType): Array[Byte] = {

--- a/src/main/scala/com/gu/thrift/serializer/ThriftSerializer.scala
+++ b/src/main/scala/com/gu/thrift/serializer/ThriftSerializer.scala
@@ -1,12 +1,8 @@
 package com.gu.thrift.serializer
 
-import com.twitter.io.Buf.ByteArray
-
-import java.lang.{Byte => JByte}
 import com.twitter.scrooge.ThriftStruct
 import org.apache.thrift.protocol.TCompactProtocol
 import org.apache.thrift.transport.TMemoryBuffer
-
 import java.nio.ByteBuffer
 
 object ThriftSerializer {

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -45,8 +45,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     "lower order bits set correctly" in {
       bytes.get(0) should be (0)
     }
-//    val decoded:String = new String(bytes.tail, "UTF-8")
-//    println(decoded)
+
     "serialized and deserialized back to itself" in {
       ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
@@ -59,7 +58,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true).array()
 
     "serialized and deserialized back to itself" in {
-      ThriftDeserializer.deserialize(bytes) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes, noHeader=true) should be(Success(notification))
     }
   }
 

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -58,7 +58,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
     val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true).array()
 
     "serialized and deserialized back to itself" in {
-      ThriftDeserializer.deserialize(bytes, noHeader=true) should be(Success(notification))
+      ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
   }
 

--- a/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
+++ b/src/test/scala/com/gu/thrift/serializer/ThriftSerializerTest.scala
@@ -12,7 +12,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
   "serialises the model correctly with ZstdType" - {
 
-    val bytes = ThriftSerializer.serializeToBytes(notification, Some(ZstdType), Some(128))
+    val bytes = ThriftSerializer.serializeToBytes(notification, Some(ZstdType), Some(128)).array()
 
     "lower order bits set correctly" in {
       bytes.head should be (2)
@@ -25,7 +25,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
   "serialises the model correctly with GzipType" - {
 
-    val bytes = ThriftSerializer.serializeToBytes(notification, Some(GzipType), Some(128))
+    val bytes = ThriftSerializer.serializeToBytes(notification, Some(GzipType), Some(128)).array()
 
     "lower order bits set correctly" in {
       bytes.head should be (1)
@@ -43,9 +43,10 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
     val bytes = ThriftSerializer.serializeToBytes(notification, Some(NoneType), Some(128))
     "lower order bits set correctly" in {
-      bytes.head should be (0)
+      bytes.get(0) should be (0)
     }
-
+//    val decoded:String = new String(bytes.tail, "UTF-8")
+//    println(decoded)
     "serialized and deserialized back to itself" in {
       ThriftDeserializer.deserialize(bytes) should be(Success(notification))
     }
@@ -55,7 +56,7 @@ class ThriftSerializerTest extends FreeSpec with Matchers {
 
     val notification = Notification(App.FaciaTool, "operation", "email", "date", Some("id"), Option("message"))
 
-    val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true)
+    val bytes = ThriftSerializer.serializeToBytes(notification, None, Some(128), true).array()
 
     "serialized and deserialized back to itself" in {
       ThriftDeserializer.deserialize(bytes) should be(Success(notification))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.4-SNAPSHOT"
+version in ThisBuild := "5.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

On CAPI, we are working on Java 11 and Graviton support for all our systems and performing library upgrades as we go.  This, in turn, requires updates on our dependencies!

- Updates Scrooge to the latest version that is currently compatible.  Required for Java 11 support.
- Support the use of `ByteBuffer` in `ThriftSerializer` and `ThriftDeserializer`.  This is to help support AWS SDKv2; the KCL version linked to SDKv2 uses ByteBuffer to wrap raw content and there is no nice, simple way to just extract the bytes out.
- Drops support for Scala 2.11, because the underlying Scrooge library has dropped support for 2.11

Major version bump because of the drop of Scala 2.11 support

## How to test

- all unit tests should pass
- when importing the new version into your project, you should be able to call `ThriftDeserializer.deserialize()` with a ByteBuffer argument as well as an `Array[Byte]` argument

## How can we measure success?

- No longer a blocker to Java11 adoption
- No longer a blocker to AWS SDKv2 adoption

## Have we considered potential risks?
There is a risk that data is corrupted if I have not got the coding right. The tests should guard against that and prerelase testing in CAPI should reassure us that this will not happen