### PR TITLE
Implementing gha-scala-release-process in this library.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import sbtrelease._
 import ReleaseStateTransformations._
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "thrift-serializer"
 organization := "com.gu"
-scalaVersion := "2.13.8"
+scalaVersion := "2.13.12"
 
 ThisBuild / versionScheme := Some("semver-spec")
 
@@ -23,35 +24,39 @@ Test / scroogeThriftSourceFolder := { baseDirectory {
 Test / scroogeThriftOutputFolder := (Test / sourceManaged).value
 Test / managedSourceDirectories += (Test / scroogeThriftOutputFolder).value
 
+scalacOptions++= Seq("-unchecked", "-release:11")
+
 // Publish settings
-scmInfo := Some(ScmInfo(url("https://github.com/guardian/thrift-serializer"),
-    "scm:git:git@github.com:guardian/thrift-serializer.git"))
+//scmInfo := Some(ScmInfo(url("https://github.com/guardian/thrift-serializer"),
+//    "scm:git:git@github.com:guardian/thrift-serializer.git"))
 
 description := "Serialize thrift models into bytes"
 
-pomExtra := (
-    <url>https://github.com/guardian/thrift-serializer</url>
-    <developers>
-        <developer>
-            <id>Reettaphant</id>
-            <name>Reetta Vaahtoranta</name>
-            <url>https://github.com/guardian</url>
-        </developer>
-    </developers>
-    )
+//pomExtra := (
+//    <url>https://github.com/guardian/thrift-serializer</url>
+//    <developers>
+//        <developer>
+//            <id>Reettaphant</id>
+//            <name>Reetta Vaahtoranta</name>
+//            <url>https://github.com/guardian</url>
+//        </developer>
+//    </developers>
+//    )
 
-licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+licenses := Seq(License.Apache2)
 
-crossScalaVersions := Seq("2.12.17", "2.13.9")
-publishTo := Some(
-    if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
-    else
-        Opts.resolver.sonatypeStaging
-)
+crossScalaVersions := Seq("2.12.18", "2.13.12")
+
+//publishTo := Some(
+//    if (isSnapshot.value)
+//        Opts.resolver.sonatypeSnapshots
+//    else
+//        Opts.resolver.sonatypeStaging
+//)
 
 releaseCrossBuild := true
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+//releasePublishArtifactsAction := PgpKeys.publishSigned.value
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
@@ -60,11 +65,11 @@ releaseProcess := Seq[ReleaseStep](
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    publishArtifacts,
+    //publishArtifacts,
     setNextVersion,
     commitNextVersion,
-    releaseStepCommand("sonatypeRelease"),
-    pushChanges
+    //releaseStepCommand("sonatypeRelease"),
+    //pushChanges
 )
 
 Test / testOptions +=

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ Test / scroogeThriftSourceFolder := { baseDirectory {
 Test / scroogeThriftOutputFolder := (Test / sourceManaged).value
 Test / managedSourceDirectories += (Test / scroogeThriftOutputFolder).value
 
-scalacOptions++= Seq("-unchecked", "-release:11")
+scalacOptions++= Seq("-deprecation", "-unchecked", "-release:11")
 
 description := "Serialize thrift models into bytes"
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,36 +26,13 @@ Test / managedSourceDirectories += (Test / scroogeThriftOutputFolder).value
 
 scalacOptions++= Seq("-unchecked", "-release:11")
 
-// Publish settings
-//scmInfo := Some(ScmInfo(url("https://github.com/guardian/thrift-serializer"),
-//    "scm:git:git@github.com:guardian/thrift-serializer.git"))
-
 description := "Serialize thrift models into bytes"
-
-//pomExtra := (
-//    <url>https://github.com/guardian/thrift-serializer</url>
-//    <developers>
-//        <developer>
-//            <id>Reettaphant</id>
-//            <name>Reetta Vaahtoranta</name>
-//            <url>https://github.com/guardian</url>
-//        </developer>
-//    </developers>
-//    )
 
 licenses := Seq(License.Apache2)
 
 crossScalaVersions := Seq("2.12.18", "2.13.12")
 
-//publishTo := Some(
-//    if (isSnapshot.value)
-//        Opts.resolver.sonatypeSnapshots
-//    else
-//        Opts.resolver.sonatypeStaging
-//)
-
 releaseCrossBuild := true
-//releasePublishArtifactsAction := PgpKeys.publishSigned.value
 releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
@@ -65,11 +42,8 @@ releaseProcess := Seq[ReleaseStep](
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    //publishArtifacts,
     setNextVersion,
     commitNextVersion,
-    //releaseStepCommand("sonatypeRelease"),
-    //pushChanges
 )
 
 Test / testOptions +=

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,11 +3,10 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "22.1.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
-
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")


### PR DESCRIPTION
## What does this change?

Simplify and automise the release process on Copip libraries by implementing `gha-scala-library-release-workflow` that is more secured, quicker, easy to deploy and removes boilerplate code from build.sbt, release.yml as well.

We granted secerts access to this repo via adding the repo name in `github-secret-access`
https://github.com/guardian/github-secret-access/pull/36

steps mentioned in Configuration has been followed.
https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md

## How to test

By making release once the PR is reviewed and merged.

## How can we measure success?

Released version and details should be available to be used by clients.