### PR TITLE
To fix Java-UnsupportedClassVersionError on usage of last release5.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ Test / scroogeThriftOutputFolder := (Test / sourceManaged).value
 Test / managedSourceDirectories += (Test / scroogeThriftOutputFolder).value
 
 scalacOptions := Seq("-deprecation", "-release:11")
-javacOptions ++= Seq("-target", "11", "-source", "11")
+javacOptions ++= Seq("--release", "11")
 
 description := "Serialize thrift models into bytes"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ name := "thrift-serializer"
 organization := "com.gu"
 scalaVersion := "2.13.12"
 
-ThisBuild / versionScheme := Some("semver-spec")
-
 libraryDependencies ++= Seq(
     "com.twitter" %% "scrooge-core" % "22.1.0",
     "org.apache.thrift" % "libthrift" % "0.17.0",
@@ -24,7 +22,8 @@ Test / scroogeThriftSourceFolder := { baseDirectory {
 Test / scroogeThriftOutputFolder := (Test / sourceManaged).value
 Test / managedSourceDirectories += (Test / scroogeThriftOutputFolder).value
 
-scalacOptions++= Seq("-deprecation", "-unchecked", "-release:11")
+scalacOptions := Seq("-deprecation", "-release:11")
+javacOptions ++= Seq("-target", "11", "-source", "11")
 
 description := "Serialize thrift models into bytes"
 


### PR DESCRIPTION
## What does this change?

We wanted to test `thrift-serializer` latest release  https://github.com/guardian/thrift-serializer/pull/27#pullrequestreview-1830242538

The client that using `thrift-serializer` is `facebook-tab`, when we use release version 5.0.3 of thrift-serializer in the facebook-tab, it was throwing error: 
[error] (Test / executeTests) java.lang.UnsupportedClassVersionError: com/gu/thrift/serializer/ByteBufferBackedInputStream has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognises class file versions up to 55.0

While troubleshooting @rtyley  has noticed that the file "ByteBufferBackedInputStream" is Java file and should be having control of javacOptions in build.sbt. Putting "--release" to 11 is setting the same version across scala and java compiler options. 

Co-authored: @rtyley 

## How to test

Make a new release (preview or final) 
and test it again in `facebook-client`

## How can we measure success?

no compilation error should be there and facebook tab should be able to use new version of thrift-serializer.
